### PR TITLE
Standardise download specification

### DIFF
--- a/src/AUMCdb_MEDS/__main__.py
+++ b/src/AUMCdb_MEDS/__main__.py
@@ -32,7 +32,7 @@ def main(cfg: DictConfig):
     # Step 0: Data downloading
     if cfg.do_download:  # pragma: no cover
         if cfg.input_dir:
-            if any(Path(cfg.input_dir).iterdir()):
+            if raw_input_dir.exists() and any(raw_input_dir.iterdir()):
                 raise ValueError(
                     f"Input directory {cfg.input_dir} is not empty. "
                     f"Please specify an empty directory to download AUMCdb. "

--- a/src/AUMCdb_MEDS/__main__.py
+++ b/src/AUMCdb_MEDS/__main__.py
@@ -31,7 +31,11 @@ def main(cfg: DictConfig):
 
     # Step 0: Data downloading
     if cfg.do_download:  # pragma: no cover
-        raw_input_dir = output_dir / "raw_input"
+        if cfg.input_dir:
+            if any(Path(cfg.input_dir).iterdir()):
+                raise ValueError(f"Input directory {cfg.input_dir} is not empty. Please specify an empty directory to download AUMCdb. Alternatively, if no input directory is specified, the data will be downloaded to the output directory.")
+        else:
+            raw_input_dir = output_dir / "raw_input"
         raw_input_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"Downloading data into {raw_input_dir}.")
         download_data(raw_input_dir, dataset_info)

--- a/src/AUMCdb_MEDS/__main__.py
+++ b/src/AUMCdb_MEDS/__main__.py
@@ -33,7 +33,12 @@ def main(cfg: DictConfig):
     if cfg.do_download:  # pragma: no cover
         if cfg.input_dir:
             if any(Path(cfg.input_dir).iterdir()):
-                raise ValueError(f"Input directory {cfg.input_dir} is not empty. Please specify an empty directory to download AUMCdb. Alternatively, if no input directory is specified, the data will be downloaded to the output directory.")
+                raise ValueError(
+                    f"Input directory {cfg.input_dir} is not empty. "
+                    f"Please specify an empty directory to download AUMCdb. "
+                    f"Alternatively, if no input directory is specified, "
+                    f"the data will be downloaded to the output directory. "
+                )
         else:
             raw_input_dir = output_dir / "raw_input"
         raw_input_dir.mkdir(parents=True, exist_ok=True)

--- a/src/AUMCdb_MEDS/dataset.yaml
+++ b/src/AUMCdb_MEDS/dataset.yaml
@@ -6,3 +6,10 @@ urls:
   dataset:
     - url: "https://lifesciences.datastations.nl/api/access/dataset/:persistentId/?persistentId=doi:10.17026/dans-22u-f8vd"
       api_key: ${oc.env:AUMCDB_API_KEY}
+      output_file: "dataverse_files.zip"
+  numeric_items:
+    - url: "https://lifesciences.datastations.nl/api/access/datafile/27884"
+      api_key: ${oc.env:AUMCDB_API_KEY}
+      output_file: "numeric_items.zip"
+
+

--- a/src/AUMCdb_MEDS/dataset.yaml
+++ b/src/AUMCdb_MEDS/dataset.yaml
@@ -2,6 +2,9 @@ dataset_name: AUMCdb
 raw_dataset_version: 1.0.2
 dataset_description: ???
 
-api_key: ${oc.env:AUMCDB_API_KEY}
+urls:
+  dataset:
+    - url: "https://lifesciences.datastations.nl/api/access/dataset/:persistentId/?persistentId=doi:10.17026/dans-22u-f8vd"
+      api_key: ${oc.env:AUMCDB_API_KEY}
 
-dataset_url: "https://lifesciences.datastations.nl/api/access/dataset/:persistentId/?persistentId=doi:10.17026/dans-22u-f8vd"
+

--- a/src/AUMCdb_MEDS/dataset.yaml
+++ b/src/AUMCdb_MEDS/dataset.yaml
@@ -11,5 +11,3 @@ urls:
     - url: "https://lifesciences.datastations.nl/api/access/datafile/27884"
       api_key: ${oc.env:AUMCDB_API_KEY}
       output_file: "numeric_items.zip"
-
-

--- a/src/AUMCdb_MEDS/dataset.yaml
+++ b/src/AUMCdb_MEDS/dataset.yaml
@@ -6,5 +6,3 @@ urls:
   dataset:
     - url: "https://lifesciences.datastations.nl/api/access/dataset/:persistentId/?persistentId=doi:10.17026/dans-22u-f8vd"
       api_key: ${oc.env:AUMCDB_API_KEY}
-
-

--- a/src/AUMCdb_MEDS/download.py
+++ b/src/AUMCdb_MEDS/download.py
@@ -44,7 +44,7 @@ def download_data(
     if do_demo:
         raise ValueError("Demo download is not currently available for AUMCdb.")
     else:
-        urls = dataset_info.get("urls",[]) #.get(["numeric_items","dataset"], [])
+        urls = dataset_info.get("urls", [])  # .get(["numeric_items","dataset"], [])
 
         for i, entry in enumerate(urls):
             url = urls[entry][0].get("url", None)
@@ -63,9 +63,7 @@ def download_data(
                 logging.info(f"Removing existing file {output_file}")
                 output_file.unlink()
             command_parts = ["cd", str(output_dir), "&&"]
-            # curl -L -O -J -H "X-Dataverse-key:$API_TOKEN"
             command_parts.extend(["curl", "-L", "-O", "-J", "-H", f"X-Dataverse-key:{key}", url])
-            # command_parts = ["curl", "-L", "--output-dir", str(output_file), "-H", f"X-Dataverse-key:{key}", url]
 
             try:
                 runner_fn(command_parts)

--- a/src/AUMCdb_MEDS/download.py
+++ b/src/AUMCdb_MEDS/download.py
@@ -11,6 +11,7 @@ from .commands import run_command
 def download_data(
     output_dir: Path,
     dataset_info: DictConfig,
+    do_demo: bool = False,
     runner_fn: callable = run_command,
 ):
     """Downloads the data specified in dataset_info.dataset_urls to the output_dir.
@@ -18,7 +19,7 @@ def download_data(
     Args:
         output_dir: The directory to download the data to.
         dataset_info: The dataset information containing the URLs to download.
-        do_demo: If True, download the demo URLs instead of the main URLs.
+        do_demo: Not currently available for AUMCdb; retained for compatibility but will raise an error if True.
         runner_fn: The function to run the command with (added for dependency injection).
 
     Raises:
@@ -26,30 +27,37 @@ def download_data(
 
     Examples:
         >>> cfg = DictConfig({
-        ...     "dataset_url": "http://example.com/dataset",
-        ...     "api_key": "[MY_API_KEY]"
+        ...     "urls": {
+        ...         "dataset": {
+        ...             "url": "http://example.com/dataset",
+        ...             "api_key": "abcdefg123"
+        ...         }
+        ...     }
         ... })
         >>> def fake_shell_succeed(cmd):
         ...     print(" ".join(cmd))
-        >>> def fake_shell_fail(cmd):
-        ...     raise ValueError(f"Failed to run {' '.join(cmd)}")
         >>> download_data(Path("data"), cfg, runner_fn=fake_shell_succeed)
-        curl -L -o data/AUMCdb.zip -H X-Dataverse-key:[MY_API_KEY] http://example.com/dataset
+        curl -L -o data/AUMCdb.zip -H X-Dataverse-key:abcdefg123 http://example.com/dataset
     """
 
-    url = dataset_info.get("dataset_url", None)
-    if url is None:
-        url = getpass("Enter the download link: ")
+    if do_demo:
+        raise ValueError("Demo download is not currently available for AUMCdb.")
+    else:
+        urls = dataset_info.urls.get("dataset", {})
+        
+        url = urls.get("url", None)
+        if url is None:
+            url = input("Enter the download link: ")
+        
+        key = urls.get("api_key", None)
+        if key is None:
+            key = getpass("Enter your API Token: ")
 
     output_file = output_dir / "AUMCdb.zip"
 
     if output_file.exists():
         logging.info(f"Removing existing file {output_file}")
         output_file.unlink()
-
-    key = dataset_info.get("api_key", None)
-    if key is None:
-        key = getpass("Enter your API Token: ")
 
     command_parts = ["curl", "-L", "-o", str(output_file), "-H", f"X-Dataverse-key:{key}", url]
 

--- a/src/AUMCdb_MEDS/download.py
+++ b/src/AUMCdb_MEDS/download.py
@@ -19,7 +19,8 @@ def download_data(
     Args:
         output_dir: The directory to download the data to.
         dataset_info: The dataset information containing the URLs to download.
-        do_demo: Not currently available for AUMCdb; retained for compatibility but will raise an error if True.
+        do_demo: Not currently available for AUMCdb; retained for compatibility
+            but will raise an error if True.
         runner_fn: The function to run the command with (added for dependency injection).
 
     Raises:
@@ -49,7 +50,7 @@ def download_data(
             url = entry.get("url", None)
             if url is None:
                 url = input("Enter the download link: ")
-            
+
             key = entry.get("api_key", None)
             if key is None:
                 key = getpass("Enter your API Token: ")

--- a/src/AUMCdb_MEDS/download.py
+++ b/src/AUMCdb_MEDS/download.py
@@ -44,24 +44,28 @@ def download_data(
     if do_demo:
         raise ValueError("Demo download is not currently available for AUMCdb.")
     else:
-        urls = dataset_info.urls.get("dataset", [])
+        urls = dataset_info.get("urls",[]) #.get(["numeric_items","dataset"], [])
 
         for i, entry in enumerate(urls):
-            url = entry.get("url", None)
+            url = urls[entry][0].get("url", None)
             if url is None:
                 url = input("Enter the download link: ")
 
-            key = entry.get("api_key", None)
+            key = urls[entry][0].get("api_key", None)
             if key is None:
                 key = getpass("Enter your API Token: ")
 
-            output_file = output_dir / f"AUMCdb_{i}.zip"
+            output_file = urls[entry][0].get("output_file", None)
 
-            if output_file.exists():
+            # output_file = output_dir #/ f"AUMCdb_{i}"
+
+            if (output_dir / output_file).exists():
                 logging.info(f"Removing existing file {output_file}")
                 output_file.unlink()
-
-            command_parts = ["curl", "-L", "-o", str(output_file), "-H", f"X-Dataverse-key:{key}", url]
+            command_parts = ["cd", str(output_dir), "&&"]
+            # curl -L -O -J -H "X-Dataverse-key:$API_TOKEN"
+            command_parts.extend(["curl", "-L", "-O", "-J", "-H", f"X-Dataverse-key:{key}", url])
+            # command_parts = ["curl", "-L", "--output-dir", str(output_file), "-H", f"X-Dataverse-key:{key}", url]
 
             try:
                 runner_fn(command_parts)


### PR DESCRIPTION
Aligns the download config structure with the [suggestion in the template](https://github.com/mmcdermott/ETL_MEDS_Template/blob/main/README.md#urls). Since only `dataset` is applicable for AUMCdb, we:

1. Throw an error for `demo`
2. Ignore `common`

In addition, `api_key` was used instead of `username` and `password`. 

To align with the MEDS-DEV dataset definitions https://github.com/mmcdermott/MEDS-DEV/issues/147 , I also added the option to specify the target directory for data download. The logic works as follows:

1. If `do_download=True` without explicitly specifying `input_dir`, default to `output_dir/raw_input`
2. If `do_download=True` with `input_dir`, check if directory exists and is not empty. Yes = raise error. No = download here.